### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/server/Trend_it/data_service/views.py
+++ b/server/Trend_it/data_service/views.py
@@ -27,5 +27,5 @@ class RandomNeighborView(APIView):
             )
         except Exception as e:
             error_trace = traceback.format_exc()
-            print(error_trace)
-            return Response({"error": f"Unexpected error: {str(e)}"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            print(error_trace)  # Log the stack trace for debugging
+            return Response({"error": "An internal error has occurred. Please try again later."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
Potential fix for [https://github.com/Kyk0/Trend_it/security/code-scanning/1](https://github.com/Kyk0/Trend_it/security/code-scanning/1)

To fix the issue, we should avoid including the exception message (`str(e)`) in the response sent to the user. Instead, we can log the full stack trace on the server for debugging purposes and return a generic error message to the user. This ensures that sensitive information is not exposed while still allowing developers to diagnose issues using server logs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
